### PR TITLE
bugfix | padding between circle and component bounds has been eliminated

### DIFF
--- a/GaugeKit/CAShapeLayer+oval.swift
+++ b/GaugeKit/CAShapeLayer+oval.swift
@@ -63,7 +63,7 @@ extension CAShapeLayer {
         var arc = CAShapeLayer()
         let rect = CGRectInset(bounds, CGFloat(lineWidth / 2.0), CGFloat(lineWidth / 2.0))
         if isCircle {
-            let arcDiameter: CGFloat = min(bounds.width, bounds.height) - 2 * lineWidth
+            let arcDiameter: CGFloat = min(bounds.width, bounds.height) - lineWidth
             let X = CGRectGetMidX(bounds)
             let Y = CGRectGetMidY(bounds)
             arc.path = UIBezierPath(ovalInRect: CGRectMake((X - (arcDiameter / 2)), (Y - (arcDiameter / 2)), arcDiameter, arcDiameter)).CGPath


### PR DESCRIPTION
I've investigated this component and found unexpected padding between circle and component. If you increase line width padding will increase too. Fixed.
