### PR TITLE
New build system support (Xcode 10)

### DIFF
--- a/GaugeKit.podspec
+++ b/GaugeKit.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true
 
-  s.source_files = 'GaugeKit/**/*'
+  s.source_files = 'GaugeKit/**/*.{h,m,swift}'
 
   s.public_header_files = 'GaugeKit/**/*.h'
   s.frameworks = 'UIKit', 'QuartzCore'


### PR DESCRIPTION
A simple commit to exclude the plist from the build phase of GaugeKit so the project can be compiled using the new build system on Xcode 10.

Related issue : #62 